### PR TITLE
Feature/mario 1476: sqs_consume_sns

### DIFF
--- a/apps/sqs_consume_sns/cloudwatch.tf
+++ b/apps/sqs_consume_sns/cloudwatch.tf
@@ -1,16 +1,50 @@
-resource "aws_cloudwatch_metric_alarm" "sqs_error_queue_alarm" {
-  alarm_name                = "${var.app_name}-ERROR-QUEUE-ALARM"
-  comparison_operator       = "GreaterThanThreshold"
+resource "aws_cloudwatch_metric_alarm" "the_alarm" {
+  alarm_name                = "${var.app_name}-STALE-MESSAGES-ALARM-1"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
-  metric_name               = "NumberOfMessagesSent"
+  metric_name               = "ApproximateAgeOfOldestMessage"
   namespace                 = "AWS/SQS"
-  period                    = "900"
-  statistic                 = "Sum"
-  threshold                 = "0"
-  alarm_description         = "This alarm monitors messages on error queue"
+  period                    = "900"  // 15 minutes
+  statistic                 = "Maximum"
+  threshold                 = "3600" // 1 hour
+  datapoints_to_alarm       = "1"
   alarm_actions             = ["${var.sns_alert_arn}"]
-  count                     = "${var.add_error_queue_cloudwatch}"
+  count                     = "${var.add_stale_message_cloudwatch}"
   dimensions {
-      QueueName = "${aws_sqs_queue.sqs_error_queue.name}"
-    }
+    QueueName = "${aws_sqs_queue.sqs_queue.name}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "the_alarm" {
+  alarm_name                = "${var.app_name}-STALE-MESSAGES-ALARM-2"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "ApproximateAgeOfOldestMessage"
+  namespace                 = "AWS/SQS"
+  period                    = "10800" // 3 hours
+  statistic                 = "Maximum"
+  threshold                 = "86400" // 1 day
+  datapoints_to_alarm       = "1"
+  alarm_actions             = ["${var.sns_alert_arn}"]
+  count                     = "${var.add_stale_message_cloudwatch}"
+  dimensions {
+    QueueName = "${aws_sqs_queue.sqs_queue.name}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "the_alarm" {
+  alarm_name                = "${var.app_name}-STALE-MESSAGES-ALARM-3"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "ApproximateAgeOfOldestMessage"
+  namespace                 = "AWS/SQS"
+  period                    = "86400"  // 1 day
+  statistic                 = "Maximum"
+  threshold                 = "259200" // 3 days
+  datapoints_to_alarm       = "1"
+  alarm_actions             = ["${var.sns_alert_arn}"]
+  count                     = "${var.add_stale_message_cloudwatch}"
+  dimensions {
+    QueueName = "${aws_sqs_queue.sqs_queue.name}"
+  }
 }

--- a/apps/sqs_consume_sns/cloudwatch.tf
+++ b/apps/sqs_consume_sns/cloudwatch.tf
@@ -1,4 +1,4 @@
-resource "aws_cloudwatch_metric_alarm" "the_alarm" {
+resource "aws_cloudwatch_metric_alarm" "stale_messages_alarm_1" {
   alarm_name                = "${var.app_name}-STALE-MESSAGES-ALARM-1"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_metric_alarm" "the_alarm" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "the_alarm" {
+resource "aws_cloudwatch_metric_alarm" "stale_messages_alarm_2" {
   alarm_name                = "${var.app_name}-STALE-MESSAGES-ALARM-2"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "the_alarm" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "the_alarm" {
+resource "aws_cloudwatch_metric_alarm" "stale_messages_alarm_3" {
   alarm_name                = "${var.app_name}-STALE-MESSAGES-ALARM-3"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"

--- a/apps/sqs_consume_sns/variables.tf
+++ b/apps/sqs_consume_sns/variables.tf
@@ -80,14 +80,14 @@ variable "sns_alert_arn" {
   default = ""
 }
 
-variable "add_error_queue_cloudwatch" {
-  default = "0"
-}
-
 variable "receive_wait_time_seconds" {
   default = "20"
 }
 
 variable "message_retention_seconds" {
   default = "1209600"
+}
+
+variable "add_stale_message_cloudwatch" {
+  default = 1
 }


### PR DESCRIPTION
Remove cloudwatch alarm from "sqs_consume_sns" module used only by SuperMario;
Add cloudwatch stale queue messages alarm (enabled by default) used only by SuperMario;
