### PR TITLE
added visibility_timeout_seconds to sqs_consume_sns

### DIFF
--- a/apps/sqs_consume_sns/sqs.tf
+++ b/apps/sqs_consume_sns/sqs.tf
@@ -2,6 +2,7 @@ resource "aws_sqs_queue" "sqs_queue" {
   name                      = "${var.app_name}"
   message_retention_seconds = "${var.message_retention_seconds}"
   receive_wait_time_seconds = "${var.receive_wait_time_seconds}"
+  visibility_timeout_seconds = "${var.visibility_timeout_seconds}"
   redrive_policy            = "{\"deadLetterTargetArn\":\"${aws_sqs_queue.sqs_error_queue.arn}\",\"maxReceiveCount\":${var.redrive_policy_retry_count}}"  
   tags = {
     "Business Unit" = "${var.tags_business_unit}"

--- a/apps/sqs_consume_sns/variables.tf
+++ b/apps/sqs_consume_sns/variables.tf
@@ -91,3 +91,7 @@ variable "message_retention_seconds" {
 variable "add_stale_message_cloudwatch" {
   default = 1
 }
+
+variable "visibility_timeout_seconds" {
+  default = 30
+}


### PR DESCRIPTION
added visibility_timeout_seconds to sqs_consume_sns, so that it could be overridden; default is 30 seconds;