### PR TITLE
Removes provider from aws_account_core_data

### DIFF
--- a/data_providers/aws_account_core_data/main.tf
+++ b/data_providers/aws_account_core_data/main.tf
@@ -1,4 +1,0 @@
-provider "aws" {
-  region = "${var.region}"
-  profile = "${var.aws_profile}"
-}

--- a/data_providers/aws_account_core_data/variables.tf
+++ b/data_providers/aws_account_core_data/variables.tf
@@ -1,11 +1,3 @@
-variable "region" {
-  default = "eu-west-1"
-}
-
-variable "aws_profile" {
-  default = "default"
-}
-
 variable "terraform_bucket" {
   default = "terraform-ap"
 }


### PR DESCRIPTION
For several times, we have seen this error when trying to remove a resource that references one of our shared modules:

`module.aichou.module.aws_account_core_data.data.aws_vpc.main: configuration for module.aichou.module.aws_account_core_data.provider.aws is not present; a provider configuration block is required for all operations`

This comes from the fact that we have `providers` configured in these shared modules. According to [Terraform's documentation](https://www.terraform.io/docs/modules/usage.html#providers-within-modules), the ideal is to have providers configured only in the root module to avoid these type of errors.

More details can be found in this [GitHub issue](https://github.com/hashicorp/terraform/issues/17365).

As a first attempt to refactor this aspect of our shared modules, I have removed the provider from `aws_account_core_data` and it solved the issue without any collateral damage.