### PR TITLE
[lambda_function_vpc] add lambda SG to outputs

### DIFF
--- a/apps/lambda_function_vpc/outputs.tf
+++ b/apps/lambda_function_vpc/outputs.tf
@@ -17,3 +17,8 @@ output "invokation_arn" {
 output "authorization_arn" {
   value = "${aws_lambda_function.app.*.arn}"
 }
+
+output "lambda_security_group" {
+  description = "SG id created for the lambda"
+  value = "${aws_security_group.sg_for_app.id}"
+}


### PR DESCRIPTION
I need the created lambda security group as an output so that I can use it later for security group based access (RDS for example)