### PR TITLE
PI-558 Set private flag to true for VPC lambda

### DIFF
--- a/apps/lambda_function_api_gateway_all_methods_passthrough/variables.tf
+++ b/apps/lambda_function_api_gateway_all_methods_passthrough/variables.tf
@@ -44,7 +44,7 @@ variable "enabled" {
   default = 1
 }
 variable "private" {
-  default = false
+  default = 1
 }
 
 variable "response_template" {


### PR DESCRIPTION
VPC lambdas are being created with private flag set to false by default.
The implication of this is both public and private subnets being added to the lambdas in AWS. And this leads to problems in API calls, the first request times out after a cold start (subsequent requests work).
When setting the flag to true, only private subnets are added to the lambda.