### PR TITLE
CMS-11964 Fix misreporting of memory use

### DIFF
--- a/apps/cloudwatch_lambda/cloudwatch.tf
+++ b/apps/cloudwatch_lambda/cloudwatch.tf
@@ -33,3 +33,49 @@ resource "aws_cloudwatch_metric_alarm" "lambda_memory_alert" {
   tags = "${local.tags}"
   count = "${var.enable_cloudwatch_alarms}"
 }
+
+resource "aws_cloudwatch_metric_alarm" "lambda_duration_alert" {
+  alarm_name          = "${var.app_name}_duration_alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  datapoints_to_alarm = "1"
+  metric_name         = "Duration"
+  namespace           = "AWS/Lambda"
+  period              = "60"
+  statistic           = "Maximum"
+  threshold           = "${var.alarm_timeout * 1000 * 0.80}"
+  alarm_description   = "${var.app_name} execution duration is approaching timeout"
+  treat_missing_data  = "ignore"
+  insufficient_data_actions = []
+  alarm_actions = ["${var.alarm_action_arn}"]
+  ok_actions = []
+  tags = "${local.tags}"
+  count = "${var.enable_cloudwatch_alarms}"
+  dimensions {
+    FunctionName = "${var.app_name}"
+    Resource     = "${var.app_name}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
+  alarm_name          = "${var.app_name}_error_alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  datapoints_to_alarm = "1"
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = "60"
+  statistic           = "Maximum"
+  threshold           = "1"
+  alarm_description   = "${var.app_name} error"
+  treat_missing_data  = "ignore"
+  insufficient_data_actions = []
+  alarm_actions = ["${var.alarm_action_arn}"]
+  ok_actions = []
+  tags = "${local.tags}"
+  count = "${local.enable_error_alarm}"
+  dimensions {
+    FunctionName = "${var.app_name}"
+    Resource     = "${var.app_name}"
+  }
+}

--- a/apps/cloudwatch_lambda/variables.tf
+++ b/apps/cloudwatch_lambda/variables.tf
@@ -23,10 +23,10 @@ variable "alarm_action_arn" {}
 variable "retention_days" {
   default = "30"
 }
-variable "log_group_name" {  
+variable "log_group_name" {
 }
 variable "pattern" {
-  default = "[type=REPORT,...,MemUsed,MemUnit]"
+  default = "[type=REPORT,...,label=\"Used:\", MemUsed,MemUnit=\"MB\"]"
 }
 variable "alarm_action_enabled" {
   default = "true"

--- a/apps/cloudwatch_lambda/variables.tf
+++ b/apps/cloudwatch_lambda/variables.tf
@@ -20,6 +20,7 @@ variable "period" {
 }
 variable "alarm_threshold" {}
 variable "alarm_action_arn" {}
+variable "alarm_timeout" {}
 variable "retention_days" {
   default = "30"
 }
@@ -32,3 +33,9 @@ variable "alarm_action_enabled" {
   default = "true"
 }
 variable "enable_cloudwatch_alarms" {}
+variable "enable_cloudwatch_error_alarm" {
+  default = 1
+}
+locals {
+  enable_error_alarm = "${var.enable_cloudwatch_alarms == 1 ? var.enable_cloudwatch_error_alarm : var.enable_cloudwatch_alarms}"
+}

--- a/apps/lambda_function/cloudwatch.tf
+++ b/apps/lambda_function/cloudwatch.tf
@@ -3,6 +3,7 @@ module "lambda_app_cloudwatch" {
   app_name                 = "${var.app_name}"
   log_group_name           = "/aws/lambda/${var.app_name}"
   alarm_threshold          = "${var.lambda_memory_alert_threshold}"
+  alarm_timeout            = "${var.timeout}"
   alarm_action_arn         = "${var.alarm_action_arn}"
   environment              = "${var.environment}"
   tags_team                = "${var.tags_team}"

--- a/apps/lambda_function_api_gateway_all_methods_passthrough/cloudwatch.tf
+++ b/apps/lambda_function_api_gateway_all_methods_passthrough/cloudwatch.tf
@@ -3,6 +3,7 @@ module "lambda_app_cloudwatch" {
   app_name                 = "${var.app_name}"
   log_group_name           = "/aws/lambda/${var.app_name}"
   alarm_threshold          = "${var.lambda_memory_alert_threshold}"
+  alarm_timeout            = "${var.timeout}"
   alarm_action_arn         = "${var.alarm_action_arn}"
   environment              = "${var.environment}"
   tags_team                = "${var.tags_team}"

--- a/apps/lambda_function_api_gateway_all_methods_passthrough_no_vpc/cloudwatch.tf
+++ b/apps/lambda_function_api_gateway_all_methods_passthrough_no_vpc/cloudwatch.tf
@@ -3,6 +3,7 @@ module "lambda_app_cloudwatch" {
   app_name                 = "${var.app_name}"
   log_group_name           = "/aws/lambda/${var.app_name}"
   alarm_threshold          = "${var.lambda_memory_alert_threshold}"
+  alarm_timeout            = "${var.timeout}"
   alarm_action_arn         = "${var.alarm_action_arn}"
   environment              = "${var.environment}"
   tags_team                = "${var.tags_team}"

--- a/apps/lambda_function_api_gateway_all_methods_passthrough_no_vpc_authentication/cloudwatch.tf
+++ b/apps/lambda_function_api_gateway_all_methods_passthrough_no_vpc_authentication/cloudwatch.tf
@@ -4,6 +4,7 @@ module "lambda_app_cloudwatch" {
   app_name = "${var.app_name}"
   log_group_name = "/aws/lambda/${var.app_name}"
   alarm_threshold = "${var.lambda_memory_alert_threshold}"
+  alarm_timeout = "${var.timeout}"
   alarm_action_arn = "${var.alarm_action_arn}"
   environment = "${var.environment}"
   tags_purpose = "${var.tags_purpose}"
@@ -15,5 +16,5 @@ module "lambda_app_cloudwatch" {
   enable_cloudwatch_alarms = "${var.enable_cloudwatch_alarms}"
   providers = {
    aws = "aws"
-  } 
+  }
 }

--- a/apps/lambda_function_api_gateway_all_methods_passthrough_no_vpc_custom_authenticator/cloudwatch.tf
+++ b/apps/lambda_function_api_gateway_all_methods_passthrough_no_vpc_custom_authenticator/cloudwatch.tf
@@ -3,6 +3,7 @@ module "lambda_app_cloudwatch" {
   app_name                 = "${var.app_name}"
   log_group_name           = "/aws/lambda/${var.app_name}"
   alarm_threshold          = "${var.lambda_memory_alert_threshold}"
+  alarm_timeout            = "${var.timeout}"
   alarm_action_arn         = "${var.alarm_action_arn}"
   environment              = "${var.environment}"
   tags_team                = "${var.tags_team}"

--- a/apps/lambda_function_scheduled_vpc/cloudwatch.tf
+++ b/apps/lambda_function_scheduled_vpc/cloudwatch.tf
@@ -17,6 +17,7 @@ module "lambda_app_cloudwatch" {
   app_name                 = "${var.app_name}"
   log_group_name           = "/aws/lambda/${var.app_name}"
   alarm_threshold          = "${var.lambda_memory_alert_threshold}"
+  alarm_timeout            = "${var.timeout}"
   alarm_action_arn         = "${var.alarm_action_arn}"
   environment              = "${var.environment}"
   tags_team                = "${var.tags_team}"

--- a/apps/lambda_function_sns/cloudwatch.tf
+++ b/apps/lambda_function_sns/cloudwatch.tf
@@ -3,6 +3,7 @@ module "lambda_app_cloudwatch" {
   app_name                 = "${var.app_name}"
   log_group_name           = "/aws/lambda/${var.app_name}"
   alarm_threshold          = "${var.lambda_memory_alert_threshold}"
+  alarm_timeout            = "${var.timeout}"
   alarm_action_arn         = "${var.alarm_action_arn}"
   environment              = "${var.environment}"
   tags_team                = "${var.tags_team}"

--- a/apps/lambda_function_sns_no_vpc/cloudwatch.tf
+++ b/apps/lambda_function_sns_no_vpc/cloudwatch.tf
@@ -3,6 +3,7 @@ module "lambda_app_cloudwatch" {
   app_name                 = "${var.app_name}"
   log_group_name           = "/aws/lambda/${var.app_name}"
   alarm_threshold          = "${var.lambda_memory_alert_threshold}"
+  alarm_timeout            = "${var.timeout}"
   alarm_action_arn         = "${var.alarm_action_arn}"
   environment              = "${var.environment}"
   tags_team                = "${var.tags_team}"

--- a/apps/lambda_function_sns_shared_vpc/cloudwatch.tf
+++ b/apps/lambda_function_sns_shared_vpc/cloudwatch.tf
@@ -3,6 +3,7 @@ module "lambda_app_cloudwatch" {
   app_name = "${var.app_name}"
   log_group_name = "/aws/lambda/${var.app_name}"
   alarm_threshold = "${var.lambda_memory_alert_threshold}"
+  alarm_timeout = "${var.timeout}"
   alarm_action_arn = "${var.alarm_action_arn}"
   environment = "${var.environment}"
   tags_team = "${var.tags_team}"

--- a/apps/lambda_function_sqs_no_vpc/cloudwatch.tf
+++ b/apps/lambda_function_sqs_no_vpc/cloudwatch.tf
@@ -3,6 +3,7 @@ module "lambda_app_cloudwatch" {
   app_name                 = "${var.app_name}"
   log_group_name           = "/aws/lambda/${var.app_name}"
   alarm_threshold          = "${var.lambda_memory_alert_threshold}"
+  alarm_timeout            = "${var.timeout}"
   alarm_action_arn         = "${var.alarm_action_arn}"
   environment              = "${var.environment}"
   tags_team                = "${var.tags_team}"
@@ -12,6 +13,7 @@ module "lambda_app_cloudwatch" {
   description              = "${var.description}"
   retention_days           = "${var.retention_days}"
   enable_cloudwatch_alarms = "${var.enable_cloudwatch_alarms}"
+  enable_cloudwatch_error_alarm = 0
   providers = {
     aws = "aws"
   }

--- a/apps/lambda_function_sqs_vpc/cloudwatch.tf
+++ b/apps/lambda_function_sqs_vpc/cloudwatch.tf
@@ -3,6 +3,7 @@ module "lambda_app_cloudwatch" {
   app_name                 = "${var.app_name}"
   log_group_name           = "/aws/lambda/${var.app_name}"
   alarm_threshold          = "${var.lambda_memory_alert_threshold}"
+  alarm_timeout            = "${var.timeout}"
   alarm_action_arn         = "${var.alarm_action_arn}"
   environment              = "${var.environment}"
   tags_team                = "${var.tags_team}"
@@ -12,6 +13,7 @@ module "lambda_app_cloudwatch" {
   description              = "${var.description}"
   retention_days           = "${var.retention_days}"
   enable_cloudwatch_alarms = "${var.enable_cloudwatch_alarms}"
+  enable_cloudwatch_error_alarm = 0
   providers = {
     aws = "aws"
   }

--- a/apps/lambda_function_vpc/cloudwatch.tf
+++ b/apps/lambda_function_vpc/cloudwatch.tf
@@ -3,6 +3,7 @@ module "lambda_app_cloudwatch" {
   app_name                 = "${var.app_name}"
   log_group_name           = "/aws/lambda/${var.app_name}"
   alarm_threshold          = "${var.lambda_memory_alert_threshold}"
+  alarm_timeout            = "${var.timeout}"
   alarm_action_arn         = "${var.alarm_action_arn}"
   environment              = "${var.environment}"
   tags_team                = "${var.tags_team}"


### PR DESCRIPTION
Reports normally look like this
REPORT RequestId: 5d41ebad-0542-4055-9bed-cfd22ae966b2 Duration: 8.57 ms Billed Duration: 100 ms Memory Size: 3008 MB Max Memory Used: 159 MB

Some times though they look like this
REPORT RequestId: aeff23d9-1588-4962-9125-0d367416c087 Duration: 984.98 ms Billed Duration: 1000 ms Memory Size: 3008 MB Max Memory Used: 159 MB **Init Duration: 1900.81 ms**

Currently we take the 2nd last value as the memory used so either we take the  value after the "Used:" label, or we take the last value with a "MB" unit, or both. I went with both.
[type=REPORT,...,Label="Used:",MemUsed,MemUnit="MB"]

Also added what seems to be missing - an alarm for almost breaching timeout & generally for errors if there is no retry/error queue (which has 3 alarms)